### PR TITLE
Specify fluid-tailwind version in docs

### DIFF
--- a/src/content/docs/guides/recipes/fluid-tailwind.mdx
+++ b/src/content/docs/guides/recipes/fluid-tailwind.mdx
@@ -29,7 +29,7 @@ To use the default theme screens and font sizes, you can import the `defaultThem
 
 
 ```javascript {1, 9-10, 13, 15-18}
-import { fluidExtractor, fluidCorePlugins, defaultThemeScreensInRems, defaultThemeFontSizeInRems } from 'https://esm.sh/fluid-tailwind?bundle-deps&external=fs';
+import { fluidExtractor, fluidCorePlugins, defaultThemeScreensInRems, defaultThemeFontSizeInRems } from 'https://esm.sh/fluid-tailwind@0.1.6?bundle-deps&external=fs';
 
 /**
  * @type {import('tailwindcss').Config} 


### PR DESCRIPTION
ESM isn't bundling the latest version of fluid-tailwind properly (see [this issue](https://github.com/esm-dev/esm.sh/issues/826)), so I added a version number that works to the example in the docs 🙂